### PR TITLE
Add `no_std` support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: rust
 sudo: required
 rust:
-- nightly
+  - nightly
 before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  - |
+    pip install 'travis-cargo<0.2' --user &&
+    export PATH=$HOME/.local/bin:$PATH
 script:
-- |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo bench &&
-  travis-cargo doc
+  - |
+    travis-cargo build &&
+    travis-cargo test &&
+    travis-cargo test -- --no-default-features &&
+    travis-cargo bench &&
+    travis-cargo doc
 after_success:
-- travis-cargo --only nightly doc-upload
-- travis-cargo coveralls
+  - travis-cargo --only nightly doc-upload
+  - travis-cargo coveralls
 env:
   global:
     secure: FcTaelK4lX/mDGAjhoXSXcWF9hqYdhF5KTMgPrW0ZKMHow7axbdtQ3Hiz4UewmCs8TDhi42LIvttbg+13USwytKNqU6ZBiyYdmf/T/BapX09v07dBuo3tsmdwNtNr2iazp1U5ibRF2P8yBOjex1WEt5QfiJx5ofApPx/d4lYKF8=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/emk/cesu8-rs"
 documentation = "http://emk.github.io/cesu8-rs/cesu8/index.html"
 
 [features]
+default = ["std"]
+std = []
 # Allow access to unstable features when being built with a nightly compiler,
 # to keep travis-cargo happy and enable access to benchmarks if we want them.
 unstable = []

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Convert between ordinary UTF-8 and [CESU-8][] encodings.
 
 CESU-8 encodes characters outside the Basic Multilingual Plane as two
 UTF-16 surrogate chacaters, which are then further re-encoded as invalid,
-3-byte UTF-8 characters.  This means that 4-byte UTF-8 sequences become
+3-byte UTF-8 characters. This means that 4-byte UTF-8 sequences become
 6-byte CESU-8 sequences.
 
 **Note that CESU-8 is only intended for internal use within tightly-coupled
@@ -23,8 +23,16 @@ Supplementary Multilingual Plane or the Supplementary Ideographic Plane.
 We also support Java's [Modified UTF-8][] encoding, which encodes `\0`
 using a multi-byte UTF-8 sequence.
 
-[CESU-8]: http://www.unicode.org/reports/tr26/tr26-2.html
-[Modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+## Features
+
+Below are the available cargo feature flags.
+
+- `std` - use the standard library (enabled by default).
+- `unstable` - Allow access to unstable features when being built with a nightly compiler,
+  to keep travis-cargo happy and enable access to benchmarks if we want them.
+
+[cesu-8]: http://www.unicode.org/reports/tr26/tr26-2.html
+[modified utf-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
 
 ## License
 


### PR DESCRIPTION
These changes should add the ability to compile in no std environments when the newly added feature `std` is disabled (enabled by default).

The new features will be documented in `README.md`.